### PR TITLE
Change rdiscount to kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ baseurl:            ""
 permalink:          /:year/:month/:day/:title.html
 
 # Markdown
-markdown:           rdiscount
+markdown:           kramdown
 
 # Navigation
 nav:


### PR DESCRIPTION
Changed rdiscount Markdown engine to kramdown due to GitHub's
announcement, where they state that they won't support rdiscount after
May 1st.
