### PR TITLE
Added RSS auto discovery to support feed reader by finding the RSS feed

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,6 +6,7 @@
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.name }}{% endif %}</title>
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,300i,600">
   <link rel="stylesheet" href="{{ site.baseurl }}/style.css">
+  <link rel="alternate" type="application/rss+xml" title="RSS Feed for {{ site.name }}" href="{{ site.baseurl }}/feed.xml" />
   {% seo %}
 </head>
 <body>


### PR DESCRIPTION
Most of the feed reader (e.g. Feedly) finding the Feed, which provides a website by discovering the meta tags. So this commit supports the feed readers by offering this meta tag.
