### PR TITLE
Allow navigation pane to have local and remote links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,8 +26,10 @@ markdown:           kramdown
 # Navigation
 nav:
   - name:           "About"
-    href:           "//kiko.gfjaru.com/about"
+    remote:         false
+    localpath:      "about"
   - name:           "Download"
+    remote:         true
     href:           "//github.com/gfjaru/Kiko/releases"
 
 # Sass

--- a/index.html
+++ b/index.html
@@ -7,7 +7,11 @@ layout: default
   </h1>
   <nav class="masthead-nav">
     {% for nav in site.nav %}
-    <a href="{{ nav.href }}">{{ nav.name }}</a>
+      {% if nav.remote %}
+      <a href="{{ nav.href }}">{{ nav.name }}</a>
+      {% else %}
+      <a href="{{ site.baseurl }}/{{ nav.localpath }}">{{ nav.name }}</a>
+      {% endif %}
     {% endfor %}
   </nav>
 </header>


### PR DESCRIPTION
Since the navigation panel can have local and remote links, it's better to provide some flexibility in the `_config.yml` for users to specify local and remote paths.